### PR TITLE
Update guzzlehttp/guzzle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "guzzlehttp/guzzle": "~4.0",
+        "guzzlehttp/guzzle": "5.*",
         "ext-mbstring": "*"
     },
     "require-dev": {


### PR DESCRIPTION
Basically because the usage of Guzzle is limited in this package I want to be able to choose which version I use. But for convenience I changed the version of the `guzzlehttp/guzzle` package to `5.*`.
