### PR TITLE
Added link_names option to config

### DIFF
--- a/src/Maknz/Slack/Client.php
+++ b/src/Maknz/Slack/Client.php
@@ -41,6 +41,13 @@ class Client {
   protected $iconType;
 
   /**
+   * Whether names should be automatically converted into mentions
+   *
+   * @var bool
+   */
+  protected $link_names;
+
+  /**
    * An array of attachments to send
    *
    * @var array
@@ -83,6 +90,8 @@ class Client {
     if (isset($attributes['username'])) $this->setUsername($attributes['username']);
 
     if (isset($attributes['icon'])) $this->setIcon($attributes['icon']);
+
+    if (isset($attributes['link_names'])) $this->setLinkNames($attributes['link_names']);
 
     $this->guzzle = $guzzle ?: new Guzzle;
   }
@@ -152,6 +161,30 @@ class Client {
   public function setUsername($username)
   {
     $this->username = $username;
+
+    return $this;
+  }
+
+  /**
+   * Get whether usernames should be automatically linked by slack
+   *
+   * @param bool $link_names
+   * @return $this
+   */
+  public function getLinkNames()
+  {
+    return $this->link_names;
+  }
+
+  /**
+   * Set whether usernames should be automatically linked by slack
+   *
+   * @param bool $link_names
+   * @return $this
+   */
+  public function setLinkNames($link_names)
+  {
+    $this->link_names = $link_names ? 1 : 0;
 
     return $this;
   }
@@ -329,7 +362,8 @@ class Client {
     $payload = [
       'text' => $message,
       'channel' => $this->channel,
-      'username' => $this->username
+      'username' => $this->username,
+      'link_names' => $this->link_names
     ];
 
     if ($icon = $this->getIcon())

--- a/src/Maknz/Slack/SlackServiceProvider.php
+++ b/src/Maknz/Slack/SlackServiceProvider.php
@@ -36,7 +36,8 @@ class SlackServiceProvider extends ServiceProvider {
         [
           'channel' => $app['config']->get('slack::channel'),
           'username' => $app['config']->get('slack::username'),
-          'icon' => $app['config']->get('slack::icon')
+          'icon' => $app['config']->get('slack::icon'),
+          'link_names' => $app['config']->get('slack::link_names')
         ],
         new Guzzle
       );

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -50,4 +50,15 @@ return [
 
   'icon' => null,
 
+  /*
+  |-------------------------------------------------------------
+  | Default link names
+  |-------------------------------------------------------------
+  |
+  | Whether slack should automatically convert @name's into mention links
+  |
+  */
+
+  'link_names' => false,
+
 ];


### PR DESCRIPTION
So slack can automatically convert @name mentions into links, which trigger mention-only notifications