### PR TITLE
Add image_url to attachment

### DIFF
--- a/src/Attachment.php
+++ b/src/Attachment.php
@@ -19,6 +19,13 @@ class Attachment {
   protected $text;
 
   /**
+   * Optional image that should appear within the attachment
+   *
+   * @var string
+   */
+  protected $image_url;
+
+  /**
    * Optional text that should appear above the formatted data
    *
    * @var string
@@ -58,6 +65,8 @@ class Attachment {
     if (isset($attributes['fallback'])) $this->setFallback($attributes['fallback']);
 
     if (isset($attributes['text'])) $this->setText($attributes['text']);
+
+    if (isset($attributes['image_url'])) $this->setImageUrl($attributes['image_url']);
 
     if (isset($attributes['pretext'])) $this->setPretext($attributes['pretext']);
 
@@ -110,6 +119,29 @@ class Attachment {
   public function setText($text)
   {
     $this->text = $text;
+
+    return $this;
+  }
+
+  /**
+   * Get the optional image to appear within the attachment
+   *
+   * @return string
+   */
+  public function getImageUrl()
+  {
+    return $this->image_url;
+  }
+
+  /**
+   * Set the optional image to appear within the attachment
+   *
+   * @param string $image_url
+   * @return $this
+   */
+  public function setImageUrl($image_url)
+  {
+    $this->image_url = $image_url;
 
     return $this;
   }
@@ -262,7 +294,8 @@ class Attachment {
       'text' => $this->getText(),
       'pretext' => $this->getPretext(),
       'color' => $this->getColor(),
-      'mrkdwn_in' => $this->getMarkdownFields()
+      'mrkdwn_in' => $this->getMarkdownFields(),
+      'image_url' => $this->getImageUrl()
     ];
 
     $data['fields'] = $this->getFieldsAsArrays();

--- a/tests/AttachmentUnitTest.php
+++ b/tests/AttachmentUnitTest.php
@@ -66,6 +66,7 @@ class AttachmentUnitTest extends PHPUnit_Framework_TestCase {
       'pretext' => 'Pretext',
       'color' => 'bad',
       'mrkdwn_in' => ['pretext', 'text'],
+      'image_url' => 'http://fake.host/image.png',
       'fields' => [
         [
           'title' => 'Title 1',

--- a/tests/ClientFunctionalTest.php
+++ b/tests/ClientFunctionalTest.php
@@ -35,6 +35,7 @@ class ClientFunctionalTest extends PHPUnit_Framework_TestCase {
       'pretext' => null,
       'color' => 'bad',
       'mrkdwn_in' => ['pretext', 'text'],
+      'image_url' => 'http://fake.host/image.png',
       'fields' => []
     ];
 
@@ -73,6 +74,7 @@ class ClientFunctionalTest extends PHPUnit_Framework_TestCase {
       'pretext' => null,
       'color' => 'bad',
       'mrkdwn_in' => [],
+      'image_url' => 'http://fake.host/image.png',
       'fields' => [
         [
           'title' => 'Field 1',


### PR DESCRIPTION
Added the ability to embed an image directly into an attachment, as per: https://api.slack.com/docs/attachments