### PR TITLE
Add support for attachment's title and title link

### DIFF
--- a/src/Attachment.php
+++ b/src/Attachment.php
@@ -33,6 +33,20 @@ class Attachment {
   protected $pretext;
 
   /**
+   * Optional title for the attachment
+   *
+   * @var string
+   */
+  protected $title;
+
+  /**
+   * Optional title link for the attachment
+   *
+   * @var string
+   */
+  protected $title_link;
+
+  /**
    * The color to use for the attachment
    *
    * @var string
@@ -75,6 +89,10 @@ class Attachment {
     if (isset($attributes['fields'])) $this->setFields($attributes['fields']);
 
     if (isset($attributes['mrkdwn_in'])) $this->setMarkdownFields($attributes['mrkdwn_in']);
+
+    if (isset($attributes['title'])) $this->setTitle($attributes['title']);
+
+    if (isset($attributes['title_link'])) $this->setTitleLink($attributes['title_link']);
   }
 
   /**
@@ -193,6 +211,52 @@ class Attachment {
   }
 
   /**
+   * Get the title to use for the attachment
+   *
+   * @return string
+   */
+  public function getTitle()
+  {
+      return $this->title;
+  }
+
+  /**
+   * Set the title to use for the attachment
+   *
+   * @param string $title
+   * @return void
+   */
+  public function setTitle($title)
+  {
+      $this->title = $title;
+
+      return $this;
+  }
+
+  /**
+   * Get the title link to use for the attachment
+   *
+   * @return string
+   */
+  public function getTitleLink()
+  {
+        return $this->title_link;
+  }
+
+  /**
+   * Set the title link to use for the attachment
+   *
+   * @param string $title_link
+   * @return void
+   */
+  public function setTitleLink($title_link)
+  {
+      $this->title_link = $title_link;
+
+      return $this;
+  }
+
+    /**
    * Get the fields for the attachment
    *
    * @return array
@@ -295,7 +359,9 @@ class Attachment {
       'pretext' => $this->getPretext(),
       'color' => $this->getColor(),
       'mrkdwn_in' => $this->getMarkdownFields(),
-      'image_url' => $this->getImageUrl()
+      'image_url' => $this->getImageUrl(),
+      'title' => $this->getTitle(),
+      'title_link' => $this->getTitleLink()
     ];
 
     $data['fields'] = $this->getFieldsAsArrays();

--- a/tests/AttachmentUnitTest.php
+++ b/tests/AttachmentUnitTest.php
@@ -67,6 +67,8 @@ class AttachmentUnitTest extends PHPUnit_Framework_TestCase {
       'color' => 'bad',
       'mrkdwn_in' => ['pretext', 'text'],
       'image_url' => 'http://fake.host/image.png',
+      'title' => 'A title',
+      'title_link' => 'http://fake.host/',
       'fields' => [
         [
           'title' => 'Title 1',

--- a/tests/ClientFunctionalTest.php
+++ b/tests/ClientFunctionalTest.php
@@ -36,7 +36,9 @@ class ClientFunctionalTest extends PHPUnit_Framework_TestCase {
       'color' => 'bad',
       'mrkdwn_in' => ['pretext', 'text'],
       'image_url' => 'http://fake.host/image.png',
-      'fields' => []
+      'fields' => [],
+      'title' => null,
+      'title_link' => null
     ];
 
     $expectedHttpData = [
@@ -75,6 +77,8 @@ class ClientFunctionalTest extends PHPUnit_Framework_TestCase {
       'color' => 'bad',
       'mrkdwn_in' => [],
       'image_url' => 'http://fake.host/image.png',
+      'title' => 'A title',
+      'title_link' => 'http://fake.host/',
       'fields' => [
         [
           'title' => 'Field 1',


### PR DESCRIPTION
This adds support for title and title_link attachment's attributes: https://api.slack.com/docs/attachments (see "title and title_link" section)
