### PR TITLE
travis: PHP 7.0 nightly added + few improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,15 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
   - hhvm
+  
+matrix:
+  allow_failures:
+    - php: 7.0
 
 before_script:
-  - composer self-update
-  - composer install --prefer-source --no-interaction --dev
+  - composer install --prefer-source --no-interaction
 
-script: phpunit
+script:
+  - phpunit


### PR DESCRIPTION
- composer self-update has no added value (managed by Travis for every patch version of PHP)
- `--dev` is by default for couple of months