### PR TITLE
Make it compatible with the new guzzle version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "guzzlehttp/guzzle": "~5.0|~4.0",
+        "guzzlehttp/guzzle": "~6.0|~5.0|~4.0",
         "ext-mbstring": "*"
     },
     "require-dev": {


### PR DESCRIPTION
Guzzle is now in version 6.0.
With a fresh installation of guzzle, I can't use this (great!) slack package, composer says:

```
- Installation request for maknz/slack ^1.5 -> satisfiable by maknz/slack[1.5.0].
- maknz/slack 1.5.0 requires guzzlehttp/guzzle ~5.0|~4.0 -> no matching package found.
```