### PR TITLE
Added .env for portability

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,14 @@ and then add the facade to your `aliases` array
 
 Publish the configuration file with:
 
+#### For Laravel 5
 ```sh
 // Laravel 5, file will be at config/slack.php
 php artisan vendor:publish --provider="Maknz\Slack\SlackServiceProviderLaravel5"
+```
 
+#### For Laravel 4
+```sh
 // Laravel 4, file will be at app/config/packages/maknz/slack/config.php
 php artisan config:publish maknz/slack
 ```

--- a/README.md
+++ b/README.md
@@ -51,6 +51,19 @@ Publish the configuration file with:
 php artisan vendor:publish --provider="Maknz\Slack\SlackServiceProviderLaravel5"
 ```
 
+Customize the client via the `Slack` facade with `.env` settings:
+
+```
+SLACK_ENDPOINT=https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX
+SLACK_CHANNEL=#general
+SLACK_USERNAME=Slack-News
+SLACK_ICON=:rocket:
+SLACK_LINK_NAMES=true
+SLACK_UNFURL_LINKS=false
+SLACK_UNFURL_MEDIA=true
+SLACK_MARKDOWN=true
+```
+
 #### For Laravel 4
 ```sh
 // Laravel 4, file will be at app/config/packages/maknz/slack/config.php

--- a/src/SlackServiceProviderLaravel5.php
+++ b/src/SlackServiceProviderLaravel5.php
@@ -12,7 +12,7 @@ class SlackServiceProviderLaravel5 extends ServiceProvider {
    */
   public function boot()
   {
-    $this->publishes([__DIR__ . '/config/config.php' => config_path('slack.php')]);
+    $this->publishes([__DIR__ . '/config/config.v5.php' => config_path('slack.php')]);
   }
 
   /**
@@ -22,7 +22,7 @@ class SlackServiceProviderLaravel5 extends ServiceProvider {
    */
   public function register()
   {
-    $this->mergeConfigFrom(__DIR__ . '/config/config.php', 'slack');
+    $this->mergeConfigFrom(__DIR__ . '/config/config.v5.php', 'slack');
 
     $this->app['maknz.slack'] = $this->app->share(function($app)
     {

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -13,7 +13,7 @@ return [
   |
   */
 
-  'endpoint' => '',
+  'endpoint' => env('SLACK_ENDPOINT'),
 
   /*
   |-------------------------------------------------------------
@@ -26,7 +26,7 @@ return [
   |
   */
 
-  'channel' => '#general',
+  'channel' => env('SLACK_CHANNEL', '#general'),
 
   /*
   |-------------------------------------------------------------
@@ -38,7 +38,7 @@ return [
   |
   */
 
-  'username' => 'Robot',
+  'username' => env('SLACK_USERNAME', 'Robot'),
 
   /*
   |-------------------------------------------------------------
@@ -51,7 +51,7 @@ return [
   |
   */
 
-  'icon' => null,
+  'icon' => env('SLACK_ICON', null),
 
   /*
   |-------------------------------------------------------------
@@ -63,7 +63,7 @@ return [
   |
   */
 
-  'link_names' => false,
+  'link_names' => env('SLACK_LINK_NAMES', false),
 
   /*
   |-------------------------------------------------------------
@@ -74,7 +74,7 @@ return [
   |
   */
 
-  'unfurl_links' => false,
+  'unfurl_links' => env('SLACK_UNFURL_LINKS', false),
 
   /*
   |-------------------------------------------------------------
@@ -86,7 +86,7 @@ return [
   |
   */
 
-  'unfurl_media' => true,
+  'unfurl_media' => env('SLACK_UNFURL_MEDIA', true),
 
   /*
   |-------------------------------------------------------------
@@ -98,7 +98,7 @@ return [
   |
   */
 
-  'allow_markdown' => true,
+  'allow_markdown' => env('SLACK_MARKDOWN', true),
 
   /*
   |-------------------------------------------------------------

--- a/src/config/config.v5.php
+++ b/src/config/config.v5.php
@@ -1,5 +1,7 @@
 <?php
-
+/**
+ * Configuration for Laravel 5
+ */
 return [
 
   /*
@@ -13,7 +15,7 @@ return [
   |
   */
 
-  'endpoint' => '',
+  'endpoint' => env('SLACK_ENDPOINT'),
 
   /*
   |-------------------------------------------------------------
@@ -26,7 +28,7 @@ return [
   |
   */
 
-  'channel' => '#general',
+  'channel' => env('SLACK_CHANNEL', '#general'),
 
   /*
   |-------------------------------------------------------------
@@ -38,7 +40,7 @@ return [
   |
   */
 
-  'username' => 'Robot',
+  'username' => env('SLACK_USERNAME', 'Robot'),
 
   /*
   |-------------------------------------------------------------
@@ -51,7 +53,7 @@ return [
   |
   */
 
-  'icon' => null,
+  'icon' => env('SLACK_ICON', null),
 
   /*
   |-------------------------------------------------------------
@@ -63,7 +65,7 @@ return [
   |
   */
 
-  'link_names' => false,
+  'link_names' => env('SLACK_LINK_NAMES', false),
 
   /*
   |-------------------------------------------------------------
@@ -74,7 +76,7 @@ return [
   |
   */
 
-  'unfurl_links' => false,
+  'unfurl_links' => env('SLACK_UNFURL_LINKS', false),
 
   /*
   |-------------------------------------------------------------
@@ -86,7 +88,7 @@ return [
   |
   */
 
-  'unfurl_media' => true,
+  'unfurl_media' => env('SLACK_UNFURL_MEDIA', true),
 
   /*
   |-------------------------------------------------------------
@@ -98,7 +100,7 @@ return [
   |
   */
 
-  'allow_markdown' => true,
+  'allow_markdown' => env('SLACK_MARKDOWN', true),
 
   /*
   |-------------------------------------------------------------


### PR DESCRIPTION
Settings are now `.env` customizable.

```
SLACK_ENDPOINT=https://hooks.slack.com/services/
SLACK_CHANNEL=#general
SLACK_USERNAME=Slack-News
SLACK_ICON=
SLACK_LINK_NAMES=true
SLACK_UNFURL_LINKS=false
SLACK_UNFURL_MEDIA=true
SLACK_MARKDOWN=true
```

After adding settings to `.env`, you can now use the `Slack` facade directly.

```
Slack::send('🎉');
```