### PR TITLE
Drop PHP 5.4, throw an exception if JSON encoding fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.4
   - 5.5
   - 5.6
   - 7.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,12 @@ php:
   - 5.5
   - 5.6
   - 7.0
+  - 7.1.0a1
   - hhvm
   
 matrix:
   allow_failures:
-    - php: 7.0
+    - php: 7.1.0a1
 
 before_script:
   - composer install --prefer-source --no-interaction

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A simple PHP package for sending messages to [Slack](https://slack.com) with [in
 
 ## Requirements
 
-* PHP 5.4 or greater. Compatible with PHP7 and hhvm.
+* PHP 5.5, 5.6, 7.0 or HHVM
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0",
+        "php": ">=5.5.0",
         "guzzlehttp/guzzle": "~6.0|~5.0|~4.0",
         "ext-mbstring": "*"
     },

--- a/src/Client.php
+++ b/src/Client.php
@@ -3,6 +3,7 @@
 namespace Maknz\Slack;
 
 use GuzzleHttp\Client as Guzzle;
+use RuntimeException;
 
 class Client
 {
@@ -370,6 +371,10 @@ class Client
         $payload = $this->preparePayload($message);
 
         $encoded = json_encode($payload, JSON_UNESCAPED_UNICODE);
+
+        if ($encoded === false) {
+            throw new RuntimeException(sprintf('JSON encoding error %s: %s', json_last_error(), json_last_error_msg()));
+        }
 
         $this->guzzle->post($this->endpoint, ['body' => $encoded]);
     }

--- a/tests/ClientFunctionalTest.php
+++ b/tests/ClientFunctionalTest.php
@@ -127,4 +127,24 @@ class ClientFunctionalTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals($expectedHttpData, $payload);
     }
+
+    public function testBadEncodingThrowsException()
+    {
+        $client = $this->getNetworkStubbedClient();
+
+        $this->setExpectedException(RuntimeException::class, 'JSON encoding error');
+
+        // Force encoding to ISO-8859-1 so we know we're providing malformed
+        // encoding to json_encode
+        $client->send(mb_convert_encoding('æøå', 'ISO-8859-1', 'UTF-8'));
+    }
+
+    protected function getNetworkStubbedClient()
+    {
+        $guzzle = Mockery::mock('GuzzleHttp\Client');
+
+        $guzzle->shouldReceive('post');
+
+        return new Client('http://fake.endpoint', [], $guzzle);
+    }
 }


### PR DESCRIPTION
Fixes #27 and replaces #28.

If JSON encoding fails (for example, by bad character encoding), a `RuntimeException` will be thrown with a descriptive message of the problem.