### PR TITLE
added Attachment Actions (buttons) with confirmations

### DIFF
--- a/src/ActionConfirmation.php
+++ b/src/ActionConfirmation.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Maknz\Slack;
+
+class ActionConfirmation
+{
+    /**
+     * The required title for the pop up window.
+     *
+     * @var string
+     */
+    protected $title;
+
+    /**
+     * The required description.
+     *
+     * @var string
+     */
+    protected $text;
+
+    /**
+     * The text label for the OK button.
+     *
+     * @var string
+     */
+    protected $okText;
+
+    /**
+     * The text label for the Cancel button.
+     *
+     * @var string
+     */
+    protected $dismissText;
+
+    /**
+     * Instantiate a new ActionConfirmation.
+     *
+     * @param array $attributes
+     * @return void
+     */
+    public function __construct(array $attributes)
+    {
+        if (isset($attributes['title'])) {
+            $this->setTitle($attributes['title']);
+        }
+
+        if (isset($attributes['text'])) {
+            $this->setText($attributes['text']);
+        }
+
+        if (isset($attributes['ok_text'])) {
+            $this->setOkText($attributes['ok_text']);
+        }
+
+        if (isset($attributes['dismiss_text'])) {
+            $this->setDismissText($attributes['dismiss_text']);
+        }
+    }
+
+    /**
+     * @return string
+     */
+    public function getTitle()
+    {
+        return $this->title;
+    }
+
+    /**
+     * @param string $title
+     * @return ActionConfirmation
+     */
+    public function setTitle($title)
+    {
+        $this->title = $title;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getText()
+    {
+        return $this->text;
+    }
+
+    /**
+     * @param string $text
+     * @return ActionConfirmation
+     */
+    public function setText($text)
+    {
+        $this->text = $text;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getOkText()
+    {
+        return $this->okText;
+    }
+
+    /**
+     * @param string $okText
+     * @return ActionConfirmation
+     */
+    public function setOkText($okText)
+    {
+        $this->okText = $okText;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDismissText()
+    {
+        return $this->dismissText;
+    }
+
+    /**
+     * @param string $dismissText
+     * @return ActionConfirmation
+     */
+    public function setDismissText($dismissText)
+    {
+        $this->dismissText = $dismissText;
+
+        return $this;
+    }
+
+    /**
+     * Get the array representation of this action confirmation.
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return [
+            'title' => $this->getTitle(),
+            'text' => $this->getText(),
+            'ok_text' => $this->getOkText(),
+            'dismiss_text' => $this->getDismissText(),
+        ];
+    }
+}

--- a/src/Attachment.php
+++ b/src/Attachment.php
@@ -99,6 +99,14 @@ class Attachment
     protected $markdown_fields = [];
 
     /**
+     * A collection of actions (buttons) to include in the attachment.
+     * A maximum of 5 actions may be provided.
+     *
+     * @var array
+     */
+    protected $actions = [];
+
+    /**
      * Instantiate a new Attachment.
      *
      * @param array $attributes
@@ -156,6 +164,10 @@ class Attachment
 
         if (isset($attributes['author_icon'])) {
             $this->setAuthorIcon($attributes['author_icon']);
+        }
+
+        if (isset($attributes['actions'])) {
+            $this->setActions($attributes['actions']);
         }
     }
 
@@ -473,6 +485,18 @@ class Attachment
     }
 
     /**
+     * Clear the actions for the attachment.
+     *
+     * @return $this
+     */
+    public function clearActions()
+    {
+        $this->actions = [];
+
+        return $this;
+    }
+
+    /**
      * Get the fields Slack should interpret in its
      * Markdown-like language.
      *
@@ -498,6 +522,54 @@ class Attachment
     }
 
     /**
+     * Get the collection of actions (buttons) to include in the attachment.
+     *
+     * @return AttachmentAction[]
+     */
+    public function getActions()
+    {
+        return $this->actions;
+    }
+
+    /**
+     * Set the collection of actions (buttons) to include in the attachment.
+     *
+     * @param array $actions
+     * @return Attachment
+     */
+    public function setActions($actions)
+    {
+        $this->clearActions();
+
+        foreach ($actions as $action) {
+            $this->addAction($action);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Add an action to the attachment.
+     *
+     * @param mixed $action
+     * @return $this
+     */
+    public function addAction($action)
+    {
+        if ($action instanceof AttachmentAction) {
+            $this->actions[] = $action;
+
+            return $this;
+        } elseif (is_array($action)) {
+            $this->actions[] = new AttachmentAction($action);
+
+            return $this;
+        }
+
+        throw new InvalidArgumentException('The attachment action must be an instance of Maknz\Slack\AttachmentAction or a keyed array');
+    }
+
+    /**
      * Convert this attachment to its array representation.
      *
      * @return array
@@ -520,6 +592,7 @@ class Attachment
         ];
 
         $data['fields'] = $this->getFieldsAsArrays();
+        $data['actions'] = $this->getActionsAsArrays();
 
         return $data;
     }
@@ -539,5 +612,22 @@ class Attachment
         }
 
         return $fields;
+    }
+
+    /**
+     * Iterates over all actions in this attachment and returns
+     * them in their array form.
+     *
+     * @return array
+     */
+    protected function getActionsAsArrays()
+    {
+        $actions = [];
+
+        foreach ($this->getActions() as $action) {
+            $actions[] = $action->toArray();
+        }
+
+        return $actions;
     }
 }

--- a/src/AttachmentAction.php
+++ b/src/AttachmentAction.php
@@ -54,7 +54,6 @@ class AttachmentAction
      */
     protected $confirm;
 
-
     /**
      * Instantiate a new AttachmentAction.
      *

--- a/src/AttachmentAction.php
+++ b/src/AttachmentAction.php
@@ -1,0 +1,229 @@
+<?php
+
+namespace Maknz\Slack;
+
+use InvalidArgumentException;
+
+class AttachmentAction
+{
+    const TYPE_BUTTON = 'button';
+
+    const STYLE_DEFAULT = 'default';
+    const STYLE_PRIMARY = 'primary';
+    const STYLE_DANGER = 'danger';
+
+    /**
+     * The required name field of the action. The name will be returned to your Action URL.
+     *
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * The required label for the action.
+     *
+     * @var string
+     */
+    protected $text;
+
+    /**
+     * Button style.
+     *
+     * @var string
+     */
+    protected $style;
+
+    /**
+     * The required type of the action.
+     *
+     * @var string
+     */
+    protected $type = self::TYPE_BUTTON;
+
+    /**
+     * Optional value. It will be sent to your Action URL.
+     *
+     * @var string
+     */
+    protected $value;
+
+    /**
+     * Confirmation field.
+     *
+     * @var ActionConfirmation
+     */
+    protected $confirm;
+
+
+    /**
+     * Instantiate a new AttachmentAction.
+     *
+     * @param array $attributes
+     * @return void
+     */
+    public function __construct(array $attributes)
+    {
+        if (isset($attributes['name'])) {
+            $this->setName($attributes['name']);
+        }
+
+        if (isset($attributes['text'])) {
+            $this->setText($attributes['text']);
+        }
+
+        if (isset($attributes['style'])) {
+            $this->setStyle($attributes['style']);
+        }
+
+        if (isset($attributes['type'])) {
+            $this->setType($attributes['type']);
+        }
+
+        if (isset($attributes['value'])) {
+            $this->setValue($attributes['value']);
+        }
+
+        if (isset($attributes['confirm'])) {
+            $this->setConfirm($attributes['confirm']);
+        }
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param string $name
+     * @return AttachmentAction
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getText()
+    {
+        return $this->text;
+    }
+
+    /**
+     * @param string $text
+     * @return AttachmentAction
+     */
+    public function setText($text)
+    {
+        $this->text = $text;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getStyle()
+    {
+        return $this->style;
+    }
+
+    /**
+     * @param string $style
+     * @return AttachmentAction
+     */
+    public function setStyle($style)
+    {
+        $this->style = $style;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    /**
+     * @param string $type
+     * @return AttachmentAction
+     */
+    public function setType($type)
+    {
+        $this->type = $type;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    /**
+     * @param string $value
+     * @return AttachmentAction
+     */
+    public function setValue($value)
+    {
+        $this->value = $value;
+
+        return $this;
+    }
+
+    /**
+     * @return ActionConfirmation
+     */
+    public function getConfirm()
+    {
+        return $this->confirm;
+    }
+
+    /**
+     * @param ActionConfirmation|array $confirm
+     * @return AttachmentAction
+     */
+    public function setConfirm($confirm)
+    {
+        if ($confirm instanceof ActionConfirmation) {
+            $this->confirm = $confirm;
+
+            return $this;
+        } elseif (is_array($confirm)) {
+            $this->confirm = new ActionConfirmation($confirm);
+
+            return $this;
+        }
+
+        throw new InvalidArgumentException('The action confirmation must be an instance of Maknz\Slack\ActionConfirmation or a keyed array');
+    }
+
+    /**
+     * Get the array representation of this attachment action.
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return [
+            'name' => $this->getName(),
+            'text' => $this->getText(),
+            'style' => $this->getStyle(),
+            'type' => $this->getType(),
+            'value' => $this->getValue(),
+            'confirm' => $this->getConfirm()->toArray(),
+        ];
+    }
+}

--- a/tests/AttachmentUnitTest.php
+++ b/tests/AttachmentUnitTest.php
@@ -97,7 +97,7 @@ class AttachmentUnitTest extends PHPUnit_Framework_TestCase
                         'text' => 'Text 1',
                         'ok_text' => 'OK Text 1',
                         'dismiss_text' => 'Dismiss Text 1',
-                    ]
+                    ],
                 ],
                 [
                     'name' => 'Name 2',

--- a/tests/AttachmentUnitTest.php
+++ b/tests/AttachmentUnitTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Maknz\Slack\Attachment;
+use Maknz\Slack\AttachmentAction;
 use Maknz\Slack\AttachmentField;
 
 class AttachmentUnitTest extends PHPUnit_Framework_TestCase
@@ -84,11 +85,97 @@ class AttachmentUnitTest extends PHPUnit_Framework_TestCase
                 'short' => false,
               ],
             ],
+            'actions' => [
+                [
+                    'name' => 'Name 1',
+                    'text' => 'Text 1',
+                    'style' => 'default',
+                    'type' => 'button',
+                    'value' => 'Value 1',
+                    'confirm' => [
+                        'title' => 'Title 1',
+                        'text' => 'Text 1',
+                        'ok_text' => 'OK Text 1',
+                        'dismiss_text' => 'Dismiss Text 1',
+                    ]
+                ],
+                [
+                    'name' => 'Name 2',
+                    'text' => 'Text 2',
+                    'style' => 'default',
+                    'type' => 'button',
+                    'value' => 'Value 2',
+                    'confirm' => [
+                        'title' => 'Title 2',
+                        'text' => 'Text 2',
+                        'ok_text' => 'OK Text 2',
+                        'dismiss_text' => 'Dismiss Text 2',
+                    ],
+                ],
+            ],
         ];
 
         $a = new Attachment($array);
 
         $this->assertSame($array, $a->toArray());
+    }
+
+    public function testAddActionAsArray()
+    {
+        $a = new Attachment([
+            'fallback' => 'Fallback',
+            'text' => 'Text',
+        ]);
+
+        $a->addAction([
+            'name' => 'Name 1',
+            'text' => 'Text 1',
+            'style' => 'default',
+            'type' => 'button',
+            'value' => 'Value 1',
+            'confirm' => [
+                'title' => 'Title 1',
+                'text' => 'Text 1',
+                'ok_text' => 'OK Text 1',
+                'dismiss_text' => 'Dismiss Text 1',
+            ],
+        ]);
+
+        $actions = $a->getActions();
+
+        $this->assertSame(1, count($actions));
+
+        $this->assertSame('Text 1', $actions[0]->getText());
+    }
+
+    public function testAddActionAsObject()
+    {
+        $a = new Attachment([
+            'fallback' => 'Fallback',
+            'text' => 'Text',
+        ]);
+
+        $ac = new AttachmentAction([
+            'name' => 'Name 1',
+            'text' => 'Text 1',
+            'style' => 'default',
+            'type' => 'button',
+            'value' => 'Value 1',
+            'confirm' => [
+                'title' => 'Title 1',
+                'text' => 'Text 1',
+                'ok_text' => 'OK Text 1',
+                'dismiss_text' => 'Dismiss Text 1',
+            ],
+        ]);
+
+        $a->addAction($ac);
+
+        $actions = $a->getActions();
+
+        $this->assertSame(1, count($actions));
+
+        $this->assertSame($ac, $actions[0]);
     }
 
     public function testAddFieldAsArray()

--- a/tests/ClientFunctionalTest.php
+++ b/tests/ClientFunctionalTest.php
@@ -158,7 +158,7 @@ class ClientFunctionalTest extends PHPUnit_Framework_TestCase
                         'text' => 'Text 1',
                         'ok_text' => 'OK Text 1',
                         'dismiss_text' => 'Dismiss Text 1',
-                    ]
+                    ],
                 ],
                 [
                     'name' => 'Name 2',

--- a/tests/ClientFunctionalTest.php
+++ b/tests/ClientFunctionalTest.php
@@ -43,6 +43,7 @@ class ClientFunctionalTest extends PHPUnit_Framework_TestCase
             'author_name' => 'Joe Bloggs',
             'author_link' => 'http://fake.host/',
             'author_icon' => 'http://fake.host/image.png',
+            'actions' => [],
         ];
 
         $expectedHttpData = [
@@ -98,6 +99,80 @@ class ClientFunctionalTest extends PHPUnit_Framework_TestCase
                 'value' => 'Value 2',
                 'short' => false,
               ],
+            ],
+            'actions' => [],
+        ];
+
+        $expectedHttpData = [
+            'username' => 'Test',
+            'channel' => '#general',
+            'text' => 'Message',
+            'link_names' => false,
+            'unfurl_links' => false,
+            'unfurl_media' => true,
+            'mrkdwn' => true,
+            'attachments' => [$attachmentArray],
+        ];
+
+        $client = new Client('http://fake.endpoint', [
+            'username' => 'Test',
+            'channel' => '#general',
+        ]);
+
+        $message = $client->createMessage()->setText('Message');
+
+        $attachment = new Attachment($attachmentArray);
+
+        $message->attach($attachment);
+
+        $payload = $client->preparePayload($message);
+
+        $this->assertEquals($expectedHttpData, $payload);
+    }
+
+    public function testMessageWithAttachmentsAndActions()
+    {
+        $attachmentArray = [
+            'fallback' => 'Some fallback text',
+            'text' => 'Some text to appear in the attachment',
+            'pretext' => null,
+            'color' => 'bad',
+            'mrkdwn_in' => [],
+            'image_url' => 'http://fake.host/image.png',
+            'thumb_url' => 'http://fake.host/image.png',
+            'title' => 'A title',
+            'title_link' => 'http://fake.host/',
+            'author_name' => 'Joe Bloggs',
+            'author_link' => 'http://fake.host/',
+            'author_icon' => 'http://fake.host/image.png',
+            'fields' => [],
+            'actions' => [
+                [
+                    'name' => 'Name 1',
+                    'text' => 'Text 1',
+                    'style' => 'default',
+                    'type' => 'button',
+                    'value' => 'Value 1',
+                    'confirm' => [
+                        'title' => 'Title 1',
+                        'text' => 'Text 1',
+                        'ok_text' => 'OK Text 1',
+                        'dismiss_text' => 'Dismiss Text 1',
+                    ]
+                ],
+                [
+                    'name' => 'Name 2',
+                    'text' => 'Text 2',
+                    'style' => 'default',
+                    'type' => 'button',
+                    'value' => 'Value 2',
+                    'confirm' => [
+                        'title' => 'Title 2',
+                        'text' => 'Text 2',
+                        'ok_text' => 'OK Text 2',
+                        'dismiss_text' => 'Dismiss Text 2',
+                    ],
+                ],
             ],
         ];
 


### PR DESCRIPTION
Slack added buttons to attachments:
https://slackhq.com/get-more-done-with-message-buttons-5fa5b283a59
https://api.slack.com/docs/message-buttons