### PR TITLE
Added optional footer attachments

### DIFF
--- a/src/Attachment.php
+++ b/src/Attachment.php
@@ -84,6 +84,27 @@ class Attachment
     protected $color = 'good';
 
     /**
+     * The text to use for the attachment footer.
+     *
+     * @var string
+     */
+    protected $footer;
+
+    /**
+     * The icon to use for the attachment footer.
+     *
+     * @var string
+     */
+    protected $footer_icon;
+
+    /**
+     * The timestamp to use for the attachment.
+     *
+     * @var \DateTime
+     */
+    protected $timestamp;
+
+    /**
      * The fields of the attachment.
      *
      * @var array
@@ -136,6 +157,18 @@ class Attachment
 
         if (isset($attributes['color'])) {
             $this->setColor($attributes['color']);
+        }
+
+        if (isset($attributes['footer'])) {
+            $this->setFooter($attributes['footer']);
+        }
+
+        if (isset($attributes['footer_icon'])) {
+            $this->setFooterIcon($attributes['footer_icon']);
+        }
+
+        if (isset($attributes['timestamp'])) {
+            $this->setTimestamp($attributes['timestamp']);
         }
 
         if (isset($attributes['fields'])) {
@@ -300,11 +333,80 @@ class Attachment
      * Set the color to use for the attachment.
      *
      * @param string $colour
-     * @return void
+     * @return $this
      */
     public function setColor($color)
     {
         $this->color = $color;
+
+        return $this;
+    }
+
+    /**
+     * Get the footer to use for the attachment.
+     *
+     * @return string
+     */
+    public function getFooter()
+    {
+        return $this->footer;
+    }
+
+    /**
+     * Set the footer text to use for the attachment.
+     *
+     * @param string $footer
+     * @return $this
+     */
+    public function setFooter($footer)
+    {
+        $this->footer = $footer;
+
+        return $this;
+    }
+
+    /**
+     * Get the footer icon to use for the attachment.
+     *
+     * @return string
+     */
+    public function getFooterIcon()
+    {
+        return $this->footer_icon;
+    }
+
+    /**
+     * Set the footer icon to use for the attachment.
+     *
+     * @param string $footerIcon
+     * @return $this
+     */
+    public function setFooterIcon($footerIcon)
+    {
+        $this->footer_icon = $footerIcon;
+
+        return $this;
+    }
+
+    /**
+     * Get the timestamp to use for the attachment.
+     *
+     * @return \DateTime
+     */
+    public function getTimestamp()
+    {
+        return $this->timestamp;
+    }
+
+    /**
+     * Set the timestamp to use for the attachment.
+     *
+     * @param \DateTime $timestamp
+     * @return $this
+     */
+    public function setTimestamp($timestamp)
+    {
+        $this->timestamp = $timestamp;
 
         return $this;
     }
@@ -323,7 +425,7 @@ class Attachment
      * Set the title to use for the attachment.
      *
      * @param string $title
-     * @return void
+     * @return $this
      */
     public function setTitle($title)
     {
@@ -346,7 +448,7 @@ class Attachment
      * Set the title link to use for the attachment.
      *
      * @param string $title_link
-     * @return void
+     * @return $this
      */
     public function setTitleLink($title_link)
     {
@@ -369,7 +471,7 @@ class Attachment
      * Set the author name to use for the attachment.
      *
      * @param string $author_name
-     * @return void
+     * @return $this
      */
     public function setAuthorName($author_name)
     {
@@ -392,7 +494,7 @@ class Attachment
      * Set the auhtor link to use for the attachment.
      *
      * @param string $author_link
-     * @return void
+     * @return $this
      */
     public function setAuthorLink($author_link)
     {
@@ -415,7 +517,7 @@ class Attachment
      * Set the author icon to use for the attachment.
      *
      * @param string $author_icon
-     * @return void
+     * @return $this
      */
     public function setAuthorIcon($author_icon)
     {
@@ -438,7 +540,7 @@ class Attachment
      * Set the fields for the attachment.
      *
      * @param array $fields
-     * @return void
+     * @return $this
      */
     public function setFields(array $fields)
     {
@@ -581,6 +683,9 @@ class Attachment
             'text' => $this->getText(),
             'pretext' => $this->getPretext(),
             'color' => $this->getColor(),
+            'footer' => $this->getFooter(),
+            'footer_icon' => $this->getFooterIcon(),
+            'ts' => $this->getTimestamp() ? $this->getTimestamp()->getTimestamp() : null,
             'mrkdwn_in' => $this->getMarkdownFields(),
             'image_url' => $this->getImageUrl(),
             'thumb_url' => $this->getThumbUrl(),

--- a/tests/AttachmentUnitTest.php
+++ b/tests/AttachmentUnitTest.php
@@ -8,11 +8,16 @@ class AttachmentUnitTest extends PHPUnit_Framework_TestCase
 {
     public function testAttachmentCreationFromArray()
     {
+        $now = new DateTime;
+
         $a = new Attachment([
             'fallback' => 'Fallback',
             'text' => 'Text',
             'pretext' => 'Pretext',
             'color' => 'bad',
+            'footer' => 'Footer',
+            'footer_icon' => 'https://platform.slack-edge.com/img/default_application_icon.png',
+            'timestamp' => $now,
             'mrkdwn_in' => ['pretext', 'text', 'fields'],
         ]);
 
@@ -27,6 +32,12 @@ class AttachmentUnitTest extends PHPUnit_Framework_TestCase
         $this->assertEquals([], $a->getFields());
 
         $this->assertEquals(['pretext', 'text', 'fields'], $a->getMarkdownFields());
+
+        $this->assertEquals('Footer', $a->getFooter());
+
+        $this->assertEquals('https://platform.slack-edge.com/img/default_application_icon.png', $a->getFooterIcon());
+
+        $this->assertEquals($now, $a->getTimestamp());
     }
 
     public function testAttachmentCreationFromArrayWithFields()
@@ -34,9 +45,6 @@ class AttachmentUnitTest extends PHPUnit_Framework_TestCase
         $a = new Attachment([
             'fallback' => 'Fallback',
             'text' => 'Text',
-            'pretext' => 'Pretext',
-            'color' => 'bad',
-            'mrkdwn_in' => [],
             'fields' => [
               [
                 'title' => 'Title 1',
@@ -60,11 +68,16 @@ class AttachmentUnitTest extends PHPUnit_Framework_TestCase
 
     public function testAttachmentToArray()
     {
-        $array = [
+        $now = new DateTime;
+
+        $in = [
             'fallback' => 'Fallback',
             'text' => 'Text',
             'pretext' => 'Pretext',
             'color' => 'bad',
+            'footer' => 'Footer',
+            'footer_icon' => 'https://platform.slack-edge.com/img/default_application_icon.png',
+            'timestamp' => $now,
             'mrkdwn_in' => ['pretext', 'text'],
             'image_url' => 'http://fake.host/image.png',
             'thumb_url' => 'http://fake.host/image.png',
@@ -115,9 +128,68 @@ class AttachmentUnitTest extends PHPUnit_Framework_TestCase
             ],
         ];
 
-        $a = new Attachment($array);
+        // Sublte difference with timestamp
+        $out = [
+            'fallback' => 'Fallback',
+            'text' => 'Text',
+            'pretext' => 'Pretext',
+            'color' => 'bad',
+            'footer' => 'Footer',
+            'footer_icon' => 'https://platform.slack-edge.com/img/default_application_icon.png',
+            'ts' => $now->getTimestamp(),
+            'mrkdwn_in' => ['pretext', 'text'],
+            'image_url' => 'http://fake.host/image.png',
+            'thumb_url' => 'http://fake.host/image.png',
+            'title' => 'A title',
+            'title_link' => 'http://fake.host/',
+            'author_name' => 'Joe Bloggs',
+            'author_link' => 'http://fake.host/',
+            'author_icon' => 'http://fake.host/image.png',
+            'fields' => [
+              [
+                'title' => 'Title 1',
+                'value' => 'Value 1',
+                'short' => false,
+              ],
+              [
+                'title' => 'Title 2',
+                'value' => 'Value 1',
+                'short' => false,
+              ],
+            ],
+            'actions' => [
+                [
+                    'name' => 'Name 1',
+                    'text' => 'Text 1',
+                    'style' => 'default',
+                    'type' => 'button',
+                    'value' => 'Value 1',
+                    'confirm' => [
+                        'title' => 'Title 1',
+                        'text' => 'Text 1',
+                        'ok_text' => 'OK Text 1',
+                        'dismiss_text' => 'Dismiss Text 1',
+                    ],
+                ],
+                [
+                    'name' => 'Name 2',
+                    'text' => 'Text 2',
+                    'style' => 'default',
+                    'type' => 'button',
+                    'value' => 'Value 2',
+                    'confirm' => [
+                        'title' => 'Title 2',
+                        'text' => 'Text 2',
+                        'ok_text' => 'OK Text 2',
+                        'dismiss_text' => 'Dismiss Text 2',
+                    ],
+                ],
+            ],
+        ];
 
-        $this->assertSame($array, $a->toArray());
+        $a = new Attachment($in);
+
+        $this->assertSame($out, $a->toArray());
     }
 
     public function testAddActionAsArray()

--- a/tests/ClientFunctionalTest.php
+++ b/tests/ClientFunctionalTest.php
@@ -11,7 +11,7 @@ class ClientFunctionalTest extends PHPUnit_Framework_TestCase
             'username' => 'Archer',
             'channel' => '@regan',
             'text' => 'Message',
-            'link_names' => false,
+            'link_names' => 0,
             'unfurl_links' => false,
             'unfurl_media' => true,
             'mrkdwn' => true,
@@ -29,11 +29,50 @@ class ClientFunctionalTest extends PHPUnit_Framework_TestCase
 
     public function testMessageWithAttachments()
     {
-        $attachmentArray = [
+        $now = new DateTime;
+
+        $attachmentInput = [
             'fallback' => 'Some fallback text',
             'text' => 'Some text to appear in the attachment',
             'pretext' => null,
             'color' => 'bad',
+            'footer' => 'Footer',
+            'footer_icon' => 'https://platform.slack-edge.com/img/default_application_icon.png',
+            'timestamp' => $now,
+            'mrkdwn_in' => ['pretext', 'text'],
+            'image_url' => 'http://fake.host/image.png',
+            'thumb_url' => 'http://fake.host/image.png',
+            'fields' => [],
+            'title' => null,
+            'title_link' => null,
+            'author_name' => 'Joe Bloggs',
+            'author_link' => 'http://fake.host/',
+            'author_icon' => 'http://fake.host/image.png',
+            'actions' => [],
+        ];
+
+        $client = new Client('http://fake.endpoint', [
+            'username' => 'Test',
+            'channel' => '#general',
+        ]);
+
+        $message = $client->createMessage()->setText('Message');
+
+        $attachment = new Attachment($attachmentInput);
+
+        $message->attach($attachment);
+
+        $payload = $client->preparePayload($message);
+
+        // Subtle difference with timestamp
+        $attachmentOutput = [
+            'fallback' => 'Some fallback text',
+            'text' => 'Some text to appear in the attachment',
+            'pretext' => null,
+            'color' => 'bad',
+            'footer' => 'Footer',
+            'footer_icon' => 'https://platform.slack-edge.com/img/default_application_icon.png',
+            'ts' => $now->getTimestamp(),
             'mrkdwn_in' => ['pretext', 'text'],
             'image_url' => 'http://fake.host/image.png',
             'thumb_url' => 'http://fake.host/image.png',
@@ -50,36 +89,28 @@ class ClientFunctionalTest extends PHPUnit_Framework_TestCase
             'username' => 'Test',
             'channel' => '#general',
             'text' => 'Message',
-            'link_names' => false,
+            'link_names' => 0,
             'unfurl_links' => false,
             'unfurl_media' => true,
             'mrkdwn' => true,
-            'attachments' => [$attachmentArray],
+            'attachments' => [$attachmentOutput],
         ];
-
-        $client = new Client('http://fake.endpoint', [
-            'username' => 'Test',
-            'channel' => '#general',
-        ]);
-
-        $message = $client->createMessage()->setText('Message');
-
-        $attachment = new Attachment($attachmentArray);
-
-        $message->attach($attachment);
-
-        $payload = $client->preparePayload($message);
 
         $this->assertEquals($expectedHttpData, $payload);
     }
 
     public function testMessageWithAttachmentsAndFields()
     {
-        $attachmentArray = [
+        $now = new DateTime;
+
+        $attachmentInput = [
             'fallback' => 'Some fallback text',
             'text' => 'Some text to appear in the attachment',
             'pretext' => null,
             'color' => 'bad',
+            'footer' => 'Footer',
+            'footer_icon' => 'https://platform.slack-edge.com/img/default_application_icon.png',
+            'timestamp' => $now,
             'mrkdwn_in' => [],
             'image_url' => 'http://fake.host/image.png',
             'thumb_url' => 'http://fake.host/image.png',
@@ -103,15 +134,35 @@ class ClientFunctionalTest extends PHPUnit_Framework_TestCase
             'actions' => [],
         ];
 
-        $expectedHttpData = [
-            'username' => 'Test',
-            'channel' => '#general',
-            'text' => 'Message',
-            'link_names' => false,
-            'unfurl_links' => false,
-            'unfurl_media' => true,
-            'mrkdwn' => true,
-            'attachments' => [$attachmentArray],
+        $attachmentOutput = [
+            'fallback' => 'Some fallback text',
+            'text' => 'Some text to appear in the attachment',
+            'pretext' => null,
+            'color' => 'bad',
+            'footer' => 'Footer',
+            'footer_icon' => 'https://platform.slack-edge.com/img/default_application_icon.png',
+            'ts' => $now->getTimestamp(),
+            'mrkdwn_in' => [],
+            'image_url' => 'http://fake.host/image.png',
+            'thumb_url' => 'http://fake.host/image.png',
+            'title' => 'A title',
+            'title_link' => 'http://fake.host/',
+            'author_name' => 'Joe Bloggs',
+            'author_link' => 'http://fake.host/',
+            'author_icon' => 'http://fake.host/image.png',
+            'fields' => [
+              [
+                'title' => 'Field 1',
+                'value' => 'Value 1',
+                'short' => false,
+              ],
+              [
+                'title' => 'Field 2',
+                'value' => 'Value 2',
+                'short' => false,
+              ],
+            ],
+            'actions' => [],
         ];
 
         $client = new Client('http://fake.endpoint', [
@@ -121,22 +172,38 @@ class ClientFunctionalTest extends PHPUnit_Framework_TestCase
 
         $message = $client->createMessage()->setText('Message');
 
-        $attachment = new Attachment($attachmentArray);
+        $attachment = new Attachment($attachmentInput);
 
         $message->attach($attachment);
 
         $payload = $client->preparePayload($message);
+
+        $expectedHttpData = [
+            'username' => 'Test',
+            'channel' => '#general',
+            'text' => 'Message',
+            'link_names' => 0,
+            'unfurl_links' => false,
+            'unfurl_media' => true,
+            'mrkdwn' => true,
+            'attachments' => [$attachmentOutput],
+        ];
 
         $this->assertEquals($expectedHttpData, $payload);
     }
 
     public function testMessageWithAttachmentsAndActions()
     {
-        $attachmentArray = [
+        $now = new DateTime;
+
+        $attachmentInput = [
             'fallback' => 'Some fallback text',
             'text' => 'Some text to appear in the attachment',
             'pretext' => null,
             'color' => 'bad',
+            'footer' => 'Footer',
+            'footer_icon' => 'https://platform.slack-edge.com/img/default_application_icon.png',
+            'timestamp' => $now,
             'mrkdwn_in' => [],
             'image_url' => 'http://fake.host/image.png',
             'thumb_url' => 'http://fake.host/image.png',
@@ -176,15 +243,51 @@ class ClientFunctionalTest extends PHPUnit_Framework_TestCase
             ],
         ];
 
-        $expectedHttpData = [
-            'username' => 'Test',
-            'channel' => '#general',
-            'text' => 'Message',
-            'link_names' => false,
-            'unfurl_links' => false,
-            'unfurl_media' => true,
-            'mrkdwn' => true,
-            'attachments' => [$attachmentArray],
+        $attachmentOutput = [
+            'fallback' => 'Some fallback text',
+            'text' => 'Some text to appear in the attachment',
+            'pretext' => null,
+            'color' => 'bad',
+            'footer' => 'Footer',
+            'footer_icon' => 'https://platform.slack-edge.com/img/default_application_icon.png',
+            'ts' => $now->getTimestamp(),
+            'mrkdwn_in' => [],
+            'image_url' => 'http://fake.host/image.png',
+            'thumb_url' => 'http://fake.host/image.png',
+            'title' => 'A title',
+            'title_link' => 'http://fake.host/',
+            'author_name' => 'Joe Bloggs',
+            'author_link' => 'http://fake.host/',
+            'author_icon' => 'http://fake.host/image.png',
+            'fields' => [],
+            'actions' => [
+                [
+                    'name' => 'Name 1',
+                    'text' => 'Text 1',
+                    'style' => 'default',
+                    'type' => 'button',
+                    'value' => 'Value 1',
+                    'confirm' => [
+                        'title' => 'Title 1',
+                        'text' => 'Text 1',
+                        'ok_text' => 'OK Text 1',
+                        'dismiss_text' => 'Dismiss Text 1',
+                    ],
+                ],
+                [
+                    'name' => 'Name 2',
+                    'text' => 'Text 2',
+                    'style' => 'default',
+                    'type' => 'button',
+                    'value' => 'Value 2',
+                    'confirm' => [
+                        'title' => 'Title 2',
+                        'text' => 'Text 2',
+                        'ok_text' => 'OK Text 2',
+                        'dismiss_text' => 'Dismiss Text 2',
+                    ],
+                ],
+            ],
         ];
 
         $client = new Client('http://fake.endpoint', [
@@ -194,11 +297,22 @@ class ClientFunctionalTest extends PHPUnit_Framework_TestCase
 
         $message = $client->createMessage()->setText('Message');
 
-        $attachment = new Attachment($attachmentArray);
+        $attachment = new Attachment($attachmentInput);
 
         $message->attach($attachment);
 
         $payload = $client->preparePayload($message);
+
+        $expectedHttpData = [
+            'username' => 'Test',
+            'channel' => '#general',
+            'text' => 'Message',
+            'link_names' => 0,
+            'unfurl_links' => false,
+            'unfurl_media' => true,
+            'mrkdwn' => true,
+            'attachments' => [$attachmentOutput],
+        ];
 
         $this->assertEquals($expectedHttpData, $payload);
     }


### PR DESCRIPTION
Replaces #51. Main difference is using PHP `DateTime` objects for the timestamp rather than UNIX time integers.