### PR TITLE
Allow the confirmation dialog to be optional & add callback_id param

### DIFF
--- a/src/Attachment.php
+++ b/src/Attachment.php
@@ -14,6 +14,13 @@ class Attachment
     protected $fallback;
 
     /**
+     * The callback_id for the button group.
+     *
+     * @var string
+     */
+    protected $callback_id;
+
+    /**
      * Optional text that should appear within the attachment.
      *
      * @var string
@@ -139,6 +146,10 @@ class Attachment
             $this->setFallback($attributes['fallback']);
         }
 
+        if (isset($attributes['callback_id'])) {
+            $this->setCallback($attributes['callback_id']);
+        }
+
         if (isset($attributes['text'])) {
             $this->setText($attributes['text']);
         }
@@ -223,6 +234,29 @@ class Attachment
     public function setFallback($fallback)
     {
         $this->fallback = $fallback;
+
+        return $this;
+    }
+
+    /**
+     * Get the callback_id text.
+     *
+     * @return string
+     */
+    public function getCallback()
+    {
+        return $this->callback_id;
+    }
+
+    /**
+     * Set the callback_id.
+     *
+     * @param string $callback_id
+     * @return $this
+     */
+    public function setCallback($callback_id)
+    {
+        $this->callback_id = $callback_id;
 
         return $this;
     }
@@ -680,6 +714,7 @@ class Attachment
     {
         $data = [
             'fallback' => $this->getFallback(),
+            'callback_id' => $this->getCallback(),
             'text' => $this->getText(),
             'pretext' => $this->getPretext(),
             'color' => $this->getColor(),

--- a/src/AttachmentAction.php
+++ b/src/AttachmentAction.php
@@ -204,6 +204,9 @@ class AttachmentAction
             $this->confirm = new ActionConfirmation($confirm);
 
             return $this;
+        } elseif (!isset($confirm)) {
+            $this->confirm = null;
+            return $this;
         }
 
         throw new InvalidArgumentException('The action confirmation must be an instance of Maknz\Slack\ActionConfirmation or a keyed array');
@@ -216,13 +219,26 @@ class AttachmentAction
      */
     public function toArray()
     {
-        return [
-            'name' => $this->getName(),
-            'text' => $this->getText(),
-            'style' => $this->getStyle(),
-            'type' => $this->getType(),
-            'value' => $this->getValue(),
-            'confirm' => $this->getConfirm()->toArray(),
-        ];
+        if ($this->getConfirm() != null)
+        {
+            return [
+                'name' => $this->getName(),
+                'text' => $this->getText(),
+                'style' => $this->getStyle(),
+                'type' => $this->getType(),
+                'value' => $this->getValue(),
+                'confirm' => $this->getConfirm()->toArray(),
+            ];
+        }
+        else
+        {
+            return [
+                'name' => $this->getName(),
+                'text' => $this->getText(),
+                'style' => $this->getStyle(),
+                'type' => $this->getType(),
+                'value' => $this->getValue(),
+            ];
+        }
     }
 }


### PR DESCRIPTION
I've updated to make button confirmations optional. Slack suggests to use confirmations sparingly:
https://api.slack.com/docs/message-buttons#guidelines_and_best_practices

Also, `callback_id` is a required attachment field:
https://api.slack.com/docs/message-buttons#attachment_fields