### PR TITLE
Add sticky channel option

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ The default settings are pretty good, but you may wish to set up default behavio
 Field | Type | Description
 ----- | ---- | -----------
 `channel` | string | The default channel that messages will be sent to
+`sticky_channel` | bool | If set to true, all messages will be sent to the default channel only (defaults to false)
 `username` | string | The default username for your bot
 `icon` | string | The default icon that messages will be sent with, either `:emoji:` or a URL to an image
 `link_names` | bool | Whether names like `@regan` or `#accounting` should be linked in the message (defaults to false)

--- a/src/Client.php
+++ b/src/Client.php
@@ -22,6 +22,16 @@ class Client
     protected $channel;
 
     /**
+     * If set to true, all messages will be sent to the default channel,
+     * even if you specify another one during the runtime.
+     *
+     * This is useful for dev environment.
+     *
+     * @var bool
+     */
+    protected $sticky_channel = false;
+
+    /**
      * The default username to send messages as.
      *
      * @var string
@@ -93,6 +103,10 @@ class Client
 
         if (isset($attributes['channel'])) {
             $this->setDefaultChannel($attributes['channel']);
+        }
+
+        if (isset($attributes['sticky_channel'])) {
+            $this->setStickyChannel($attributes['sticky_channel']);
         }
 
         if (isset($attributes['username'])) {
@@ -179,6 +193,22 @@ class Client
     public function setDefaultChannel($channel)
     {
         $this->channel = $channel;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isStickyChannel()
+    {
+        return $this->sticky_channel;
+    }
+
+    /**
+     * @param bool $sticky_channel
+     */
+    public function setStickyChannel($sticky_channel)
+    {
+        $this->sticky_channel = $sticky_channel;
     }
 
     /**
@@ -385,7 +415,7 @@ class Client
     {
         $payload = [
             'text' => $message->getText(),
-            'channel' => $message->getChannel(),
+            'channel' => $this->isStickyChannel() ? $this->getDefaultChannel() : $message->getChannel(),
             'username' => $message->getUsername(),
             'link_names' => $this->getLinkNames() ? 1 : 0,
             'unfurl_links' => $this->getUnfurlLinks(),

--- a/tests/ClientFunctionalTest.php
+++ b/tests/ClientFunctionalTest.php
@@ -317,6 +317,31 @@ class ClientFunctionalTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($expectedHttpData, $payload);
     }
 
+    public function testMessageWithStickyChannel()
+    {
+        $expectedHttpData = [
+            'username' => 'Archer',
+            'channel' => 'test',
+            'text' => 'Message',
+            'link_names' => 0,
+            'unfurl_links' => false,
+            'unfurl_media' => true,
+            'mrkdwn' => true,
+            'attachments' => [],
+        ];
+
+        $client = new Client('http://fake.endpoint', [
+            'channel' => 'test',
+            'sticky_channel' => true,
+        ]);
+
+        $message = $client->to('@regan')->from('Archer')->setText('Message');
+
+        $payload = $client->preparePayload($message);
+
+        $this->assertEquals($expectedHttpData, $payload);
+    }
+
     public function testBadEncodingThrowsException()
     {
         $client = $this->getNetworkStubbedClient();


### PR DESCRIPTION
Closes #40

With this option, all message will be sent to the default channel only.

This is useful for dev environment when you want to concentrate all test message to a specific test channel.

This was dicussed for a long time on #40 but we finally get an agreement with @Gummibeer at https://github.com/maknz/slack/issues/40#issuecomment-219778449 :wink: 

@maknz Could you please review the code and merge it if it looks OK? Thanks.
