### PR TITLE
updated the guzzle dependency version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.5.0",
-        "guzzlehttp/guzzle": "~6.0|~5.0|~4.0|~3.8.1",
+        "guzzlehttp/guzzle": "3.8.1",
         "ext-mbstring": "*"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.5.0",
-        "guzzlehttp/guzzle": "~6.0|~5.0|~4.0",
+        "guzzlehttp/guzzle": "~6.0|~5.0|~4.0|~3.8.1",
         "ext-mbstring": "*"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.5.0",
-        "guzzlehttp/guzzle": "3.8.1",
+        "guzzlehttp/guzzle": "~6.0|~5.0|~4.0|~3.8.1",
         "ext-mbstring": "*"
     },
     "require-dev": {


### PR DESCRIPTION
I noticed that this project currently has a dependency for Guzzle versions 4.0+.

Is it mandatory that Guzzle will be at those versions?
I am currently working on a project that must require Guzzle 3.8.1 and I was wondering if it's possible to lower the dependency version. 

Thanks