### PR TITLE
App share was deprecated in laravel 5.4. Using app singleton.

### DIFF
--- a/src/SlackServiceProviderLaravel5.php
+++ b/src/SlackServiceProviderLaravel5.php
@@ -24,7 +24,7 @@ class SlackServiceProviderLaravel5 extends ServiceProvider {
   {
     $this->mergeConfigFrom(__DIR__ . '/config/config.php', 'slack');
 
-    $this->app['maknz.slack'] = $this->app->share(function($app)
+    $this->app->singleton('maknz.slack', function($app)
     {
       return new Client(
         $app['config']->get('slack.endpoint'),


### PR DESCRIPTION
You master was off from the tag so I made a new branch, laravel5.4. 

I changed one line of code because app->share was deprecated in 5.4 for app->singleton.

---

[**`share` Method Removed**](https://laravel.com/docs/5.4/upgrade)


The `share` method has been removed from the container. This was a legacy method that has not been documented in several years. If you are using this method, you should begin using the  singleton method instead:

    $container->singleton('foo', function () {
        return 'foo';
    });